### PR TITLE
Minor build warning fixes

### DIFF
--- a/common/cmd.c
+++ b/common/cmd.c
@@ -36,6 +36,7 @@
 #include <ctype.h>
 #include <strings.h>
 #include "include/types.h"
+#include "include/numatop.h"
 #include "include/cmd.h"
 #include "include/page.h"
 #include "include/win.h"

--- a/common/include/cmd.h
+++ b/common/include/cmd.h
@@ -227,8 +227,6 @@ typedef struct _switch {
 #define	CMD_UNCOREQPI(cmd) \
 	((cmd_uncoreqpi_t *)(cmd))
 
-extern int g_sortkey;
-
 extern void switch_table_init(void);
 extern int cmd_id_get(char);
 extern void cmd_execute(cmd_t *, boolean_t *);

--- a/common/include/numatop.h
+++ b/common/include/numatop.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Intel Corporation nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _NUMATOP_H
+#define	_NUMATOP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern precise_type_t g_precise;
+
+/* Number of online CPUs */
+extern int g_ncpus;
+
+/* The sorting key */
+extern int g_sortkey;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NUMATOP_H */

--- a/common/include/os/pfwrapper.h
+++ b/common/include/os/pfwrapper.h
@@ -33,6 +33,7 @@
 #include <pthread.h>
 #include "linux/perf_event.h"
 #include "../types.h"
+#include "../numatop.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,8 +107,6 @@ typedef struct _pf_ll_rbrec {
 	uint64_t latency;
 	unsigned int ip_num;
 } pf_ll_rbrec_t;
-
-extern precise_type_t g_precise;
 
 struct _perf_cpu;
 struct _perf_pqos;

--- a/common/include/page.h
+++ b/common/include/page.h
@@ -60,9 +60,6 @@ typedef struct _page_list {
 	int npages;
 } page_list_t;
 
-extern int g_scr_height;
-extern int g_scr_width;
-
 extern void page_list_init(void);
 extern void page_list_fini(void);
 extern page_t *page_create(cmd_t *);

--- a/common/include/perf.h
+++ b/common/include/perf.h
@@ -181,8 +181,6 @@ typedef struct _perf_ctl {
 	uint64_t last_ms_pqos;
 } perf_ctl_t;
 
-extern precise_type_t g_precise;
-
 extern int perf_init(void);
 extern void perf_fini(void);
 extern int perf_allstop(void);

--- a/common/include/reg.h
+++ b/common/include/reg.h
@@ -67,6 +67,10 @@ typedef struct _win_reg {
 	scroll_line_t scroll;
 } win_reg_t;
 
+/* Screen dimension */
+extern int g_scr_height;
+extern int g_scr_width;
+
 extern int reg_init(win_reg_t *, int, int, int, int, unsigned int);
 extern void reg_buf_init(win_reg_t *, void *,
 	void (*line_get)(win_reg_t *, int, char *, int));

--- a/common/include/util.h
+++ b/common/include/util.h
@@ -86,7 +86,6 @@ typedef struct _dump_ctl {
 
 extern pid_t g_numatop_pid;
 extern struct timeval g_tvbase;
-extern int g_ncpus;
 extern int g_pagesize;
 extern double g_nsofclk;
 

--- a/common/include/win.h
+++ b/common/include/win.h
@@ -419,12 +419,6 @@ typedef struct _dyn_warn {
 /* CPU unhalted cycles in a second */
 extern uint64_t g_clkofsec;
 
-/* Number of online CPUs */
-extern int g_ncpus;
-
-/* The sorting key */
-extern int g_sortkey;
-
 extern void win_fix_init(void);
 extern void win_fix_fini(void);
 extern void win_warn_msg(warn_type_t);

--- a/common/include/win.h
+++ b/common/include/win.h
@@ -416,10 +416,6 @@ typedef struct _dyn_warn {
 #define	DYN_PQOS_MBM_PROC(page) \
 	((dyn_pqos_mbm_proc_t *)((page)->dyn_win.dyn))
 
-/* Screen dimension */
-extern int g_scr_height;
-extern int g_scr_width;
-
 /* CPU unhalted cycles in a second */
 extern uint64_t g_clkofsec;
 

--- a/common/lwp.c
+++ b/common/lwp.c
@@ -147,8 +147,8 @@ lwp_sort_next(track_proc_t *proc)
 static int
 id_cmp(const void *a, const void *b)
 {
-	int *id1 = (int *)a;
-	int *id2 = (int *)b;
+	const int *id1 = (const int *)a;
+	const int *id2 = (const int *)b;
 
 	if (*id1 > *id2) {
 		return (1);

--- a/common/os/map.c
+++ b/common/os/map.c
@@ -265,8 +265,8 @@ map_proc_fini(track_proc_t *proc)
 static int
 entryaddr_cmp(const void *p1, const void *p2)
 {
-	uint64_t addr = *(uint64_t *)p1;
-	map_entry_t *entry = (map_entry_t *)p2;
+	const uint64_t addr = *(const uint64_t *)p1;
+	const map_entry_t *entry = (const map_entry_t *)p2;
 		
 	if (addr < entry->start_addr) {
 		return (-1);

--- a/common/os/node.c
+++ b/common/os/node.c
@@ -415,7 +415,7 @@ node_cpu_traverse(pfn_perf_cpu_op_t func, void *arg, boolean_t err_ret,
 	return (0);
 }
 
-uint64_t
+static uint64_t
 countval_sum(count_value_t *countval_arr, int cpuid_max, int nid,
 	count_id_t count_id)
 {

--- a/common/os/node.c
+++ b/common/os/node.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <assert.h>
 #include "../include/types.h"
+#include "../include/numatop.h"
 #include "../include/util.h"
 #include "../include/os/os_util.h"
 #include "../include/os/pfwrapper.h"

--- a/common/os/os_perf.c
+++ b/common/os/os_perf.c
@@ -343,7 +343,7 @@ cpu_ll_stop(perf_cpu_t *cpu, void *arg)
 	return (0);
 }
 
-int
+static int
 llrec_add(perf_llrecgrp_t *grp, pf_ll_rec_t *record)
 {
 	os_perf_llrec_t *llrec;

--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -40,6 +40,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <locale.h>
+#include <math.h>
 #include "../include/types.h"
 #include "../include/numatop.h"
 #include "../include/util.h"
@@ -225,7 +226,7 @@ calibrate_cpuinfo(double *nsofclk, uint64_t *clkofsec)
 	free(line);
 	fclose(f);
 
-	if (freq == 0.0) {
+	if (fabsl(freq) < 1.0E-6) {
 		return (-1);
 	}
 

--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -41,6 +41,7 @@
 #include <limits.h>
 #include <locale.h>
 #include "../include/types.h"
+#include "../include/numatop.h"
 #include "../include/util.h"
 #include "../include/os/os_util.h"
 

--- a/common/os/os_win.c
+++ b/common/os/os_win.c
@@ -90,8 +90,8 @@ os_nodeoverview_data_build(char *buf, int size, nodeoverview_line_t *line,
 static int
 cpuid_cmp(const void *a, const void *b)
 {
-	int *id1 = (int *)a;
-	int *id2 = (int *)b;
+	const int *id1 = (const int *)a;
+	const int *id2 = (const int *)b;
 
 	if (*id1 > *id2) {
 		return (1);
@@ -553,8 +553,8 @@ os_llcallchain_win_destroy(dyn_win_t *win)
 static int
 bufaddr_cmp(const void *p1, const void *p2)
 {
-	uint64_t addr = (uint64_t)p1;
-	bufaddr_t *bufaddr = (bufaddr_t *)p2;
+	const uint64_t addr = (const uint64_t)p1;
+	const bufaddr_t *bufaddr = (const bufaddr_t *)p2;
 
 	if (addr < bufaddr->addr) {
 		return (-1);

--- a/common/os/sym.c
+++ b/common/os/sym.c
@@ -340,8 +340,8 @@ L_EXIT:
 static int
 sym_cmp(const void *a, const void *b)
 {
-	sym_item_t *s1 = (sym_item_t *)a;
-	sym_item_t *s2 = (sym_item_t *)b;
+	const sym_item_t *s1 = (const sym_item_t *)a;
+	const sym_item_t *s2 = (const sym_item_t *)b;
 
 	if (s1->off < s2->off) {
 		return (-1);
@@ -743,8 +743,8 @@ sym_free(sym_t *sym)
 static int
 off_cmp(const void *a, const void *b)
 {
-	uint64_t off = *(uint64_t *)a;
-	sym_item_t *item = (sym_item_t *)b;
+	const uint64_t off = *(const uint64_t *)a;
+	const sym_item_t *item = (const sym_item_t *)b;
 	
 	if (off >= item->off + item->size) {
 		return (1);

--- a/common/proc.c
+++ b/common/proc.c
@@ -290,8 +290,8 @@ proc_alloc(void)
 static int
 lwp_id_cmp(const void *a, const void *b)
 {
-	track_lwp_t *lwp1 = (track_lwp_t *)a;
-	track_lwp_t *lwp2 = *((track_lwp_t **)b);
+	const track_lwp_t *lwp1 = (const track_lwp_t *)a;
+	const track_lwp_t *lwp2 = *((track_lwp_t *const *)b);
 
 	if (lwp1->id > lwp2->id) {
 		return (1);
@@ -336,8 +336,8 @@ proc_lwp_find(track_proc_t *proc, id_t lwpid)
 static int
 lwp_key_cmp(const void *a, const void *b)
 {
-	track_lwp_t *lwp1 = *((track_lwp_t **)a);
-	track_lwp_t *lwp2 = *((track_lwp_t **)b);
+	const track_lwp_t *lwp1 = *((track_lwp_t *const *)a);
+	const track_lwp_t *lwp2 = *((track_lwp_t *const *)b);
 
 	if (lwp1->key > lwp2->key) {
 		return (-1);
@@ -481,8 +481,8 @@ proc_key_compute(track_proc_t *proc, void *arg, boolean_t *end)
 static int
 proc_key_cmp(const void *a, const void *b)
 {
-	track_proc_t *proc1 = *((track_proc_t **)a);
-	track_proc_t *proc2 = *((track_proc_t **)b);
+	const track_proc_t *proc1 = *((track_proc_t *const *)a);
+	const track_proc_t *proc2 = *((track_proc_t *const *)b);
 
 	if (proc1->key > proc2->key) {
 		return (-1);
@@ -498,8 +498,8 @@ proc_key_cmp(const void *a, const void *b)
 static int
 proc_pid_cmp(const void *a, const void *b)
 {
-	track_proc_t *proc1 = *((track_proc_t **)a);
-	track_proc_t *proc2 = *((track_proc_t **)b);
+	const track_proc_t *proc1 = *((track_proc_t *const *)a);
+	const track_proc_t *proc2 = *((track_proc_t *const *)b);
 
 	if (proc1->pid > proc2->pid) {
 		return (1);
@@ -668,8 +668,8 @@ proc_obsolete(pid_t pid)
 static int
 pid_cmp(const void *a, const void *b)
 {
-	pid_t *pid1 = (pid_t *)a;
-	pid_t *pid2 = (pid_t *)b;
+	const pid_t *pid1 = (const pid_t *)a;
+	const pid_t *pid2 = (const pid_t *)b;
 
 	if (*pid1 > *pid2) {
 		return (1);

--- a/common/util.c
+++ b/common/util.c
@@ -57,7 +57,6 @@ static FILE *s_logfile;
 static debug_ctl_t s_debug_ctl;
 static dump_ctl_t s_dump_ctl;
 static char s_exit_msg[EXIT_MSG_SIZE];
-static dump_ctl_t s_dump_ctl;
 
 static unsigned int msdiff(struct timeval *, struct timeval *);
 

--- a/common/win.c
+++ b/common/win.c
@@ -2270,8 +2270,8 @@ win_lat_buf_fill(lat_line_t *lat_buf, int nlines, track_proc_t *proc,
 int
 win_lat_cmp(const void *p1, const void *p2)
 {
-	lat_line_t *l1 = (lat_line_t *)p1;
-	lat_line_t *l2 = (lat_line_t *)p2;
+	const lat_line_t *l1 = (const lat_line_t *)p1;
+	const lat_line_t *l2 = (const lat_line_t *)p2;
 
 	if (l1->naccess < l2->naccess) {
 		return (1);

--- a/common/win.c
+++ b/common/win.c
@@ -39,6 +39,7 @@
 #include <signal.h>
 #include <curses.h>
 #include "include/types.h"
+#include "include/numatop.h"
 #include "include/util.h"
 #include "include/disp.h"
 #include "include/reg.h"

--- a/common/win.c
+++ b/common/win.c
@@ -2171,7 +2171,7 @@ lat_win_destroy(dyn_win_t *win)
  * probably is cut to:
  * ../usr/src/cmd/numatop/amd64/numatop
  */
-void
+static void
 bufdesc_cut(char *dst_desc, int dst_size, char *src_desc)
 {
 	int src_len;


### PR DESCRIPTION
I've been building numatop against gcc 6.2.0 with some extra build flags to see if there are any minor issues that gcc finds. Just a few minor changes to the code to get a clean build.  The largest changes are to stop duplicate extern declarations that were scattered around  various headers.

For building checking used:

CFLAGS += -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations \
-Wmissing-format-attribute -Wno-long-long -Wpacked \
-Wredundant-decls -Wshadow -Wno-missing-field-initializers \
-Wno-missing-braces -Wno-sign-compare -Wno-multichar