### PR TITLE
test: mgen: use %u format specifier for unsigned int s_randseed

### DIFF
--- a/common/numatop.c
+++ b/common/numatop.c
@@ -76,7 +76,7 @@ main(int argc, char *argv[])
 	int ret = 1, debug_level = 0;
 	FILE *log = NULL, *dump = NULL;
 	boolean_t locked = B_FALSE;
-	char c;
+	int c;
 
 	if (!os_authorized()) {
 		return (1);		

--- a/test/mgen/mgen.c
+++ b/test/mgen/mgen.c
@@ -634,7 +634,7 @@ dependent_read(void *buf, int cpu_consumer, int node_alloc, int meas_sec)
 	fprintf(stdout, "\nGenerating memory access from cpu%d to node%d for ~%ds ...\n",
 	    cpu_consumer, node_alloc, meas_sec);
 
-	fprintf(stdout, "(random seed to build random address array is %d.)\n", s_randseed);
+	fprintf(stdout, "(random seed to build random address array is %u.)\n", s_randseed);
 
 	printf("\n%9s   %13s\n", "Time", "Latency(ns)");
 	printf("-------------------------\n");


### PR DESCRIPTION
Use the correct printf %u format specifier for the s_randseed
unsigned int variable.

Signed-off-by: Colin Ian King <colin.king@canonical.com>