### PR TITLE
Powerpc: More improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS = -g
 LDLIBS = -lncurses -lpthread -lnuma
 
 COMMON_OBJS = cmd.o disp.o lwp.o numatop.o page.o perf.o \
-	proc.o reg.o util.o win.o
+	proc.o reg.o util.o win.o ui_perf_map.o
 
 OS_OBJS = os_cmd.o os_perf.o os_win.o node.o map.o \
 	os_util.o plat.o pfwrapper.o sym.o os_page.o
@@ -18,12 +18,13 @@ ARCH := $(shell uname -m)
 
 ifneq (,$(filter $(ARCH),ppc64le ppc64))
 ARCH_PATH = ./powerpc
-ARCH_OBJS = $(ARCH_PATH)/power8.o $(ARCH_PATH)/plat.o $(ARCH_PATH)/util.o
+ARCH_OBJS = $(ARCH_PATH)/power8.o $(ARCH_PATH)/plat.o $(ARCH_PATH)/util.o \
+	$(ARCH_PATH)/ui_perf_map.o
 else
 ARCH_PATH = ./intel
 ARCH_OBJS = $(ARCH_PATH)/wsm.o $(ARCH_PATH)/snb.o $(ARCH_PATH)/nhm.o \
 	$(ARCH_PATH)/bdw.o $(ARCH_PATH)/skl.o $(ARCH_PATH)/plat.o \
-	$(ARCH_PATH)/util.o
+	$(ARCH_PATH)/util.o $(ARCH_PATH)/ui_perf_map.o
 endif
 
 all: $(PROG)

--- a/README
+++ b/README
@@ -51,3 +51,7 @@ E5-16xx/24xx/26xx/46xx-series had better be updated to latest CPU microcode
 
 To learn about NumaTOP, please visit http://01.org/numatop
 
+PowerPC Support:
+----------------
+NumaTOP is also supported on PowerPC. Please check powerpc/FEATURES file
+for more details.

--- a/common/include/lwp.h
+++ b/common/include/lwp.h
@@ -67,7 +67,7 @@ extern void lwp_enum_update(struct _track_proc *);
 extern int lwp_refcount_inc(track_lwp_t *);
 extern void lwp_refcount_dec(track_lwp_t *);
 extern int lwp_key_compute(track_lwp_t *, void *, boolean_t *end);
-extern int lwp_countval_update(track_lwp_t *, int, count_id_t, uint64_t);
+extern int lwp_countval_update(track_lwp_t *, int, perf_count_id_t, uint64_t);
 extern int lwp_intval_get(track_lwp_t *);
 extern void lwp_intval_update(struct _track_proc *, int intval_ms);
 extern void lwp_quitting_set(track_lwp_t *);

--- a/common/include/os/node.h
+++ b/common/include/os/node.h
@@ -115,12 +115,12 @@ extern void node_group_unlock(void);
 extern node_t *node_by_cpu(int);
 extern int node_ncpus(node_t *);
 extern int node_intval_get(void);
-extern void node_countval_update(node_t *, count_id_t, uint64_t);
-extern uint64_t node_countval_get(node_t *, count_id_t);
+extern void node_countval_update(node_t *, perf_count_id_t, uint64_t);
+extern uint64_t node_countval_get(node_t *, ui_count_id_t);
 extern void node_meminfo(int, node_meminfo_t *);
 extern int node_cpu_traverse(pfn_perf_cpu_op_t, void *, boolean_t,
 	pfn_perf_cpu_op_t);
-extern uint64_t node_countval_sum(count_value_t *, int, int, count_id_t);
+extern uint64_t node_countval_sum(count_value_t *, int, int, ui_count_id_t);
 extern perf_cpu_t* node_cpus(node_t *);
 extern void node_intval_update(int);
 extern void node_profiling_clear(void);

--- a/common/include/os/os_perf.h
+++ b/common/include/os/os_perf.h
@@ -39,7 +39,7 @@ extern "C" {
 #endif
 
 #define PERF_REC_NUM	512
-#define PERF_FD_NUM		NCPUS_MAX * COUNT_NUM
+#define PERF_FD_NUM		NCPUS_MAX * PERF_COUNT_NUM
 #define INVALID_CODE_UMASK	(uint64_t)(-1)
 #define PERF_PQOS_CMT_MAX	10
 
@@ -61,7 +61,7 @@ typedef struct _os_perf_llrec {
 
 typedef struct _perf_cpu {
 	int cpuid;
-	int fds[COUNT_NUM];
+	int fds[PERF_COUNT_NUM];
 	int group_idx;
 	int map_len;
 	int map_mask;
@@ -99,7 +99,9 @@ extern boolean_t os_profiling_started(struct _perf_ctl *);
 extern int os_profiling_start(struct _perf_ctl *, union _perf_task *);
 extern int os_profiling_smpl(struct _perf_ctl *, union _perf_task *, int *);
 extern int os_profiling_partpause(struct _perf_ctl *, union _perf_task *);
+extern int os_profiling_multipause(struct _perf_ctl *, union _perf_task *);
 extern int os_profiling_restore(struct _perf_ctl *, union _perf_task *);
+extern int os_profiling_multi_restore(struct _perf_ctl *, union _perf_task *);
 extern int os_callchain_start(struct _perf_ctl *, union _perf_task *);
 extern int os_callchain_smpl(struct _perf_ctl *, union _perf_task *, int *);
 extern int os_ll_start(struct _perf_ctl *, union _perf_task *);
@@ -107,8 +109,10 @@ extern int os_ll_smpl(struct _perf_ctl *, union _perf_task *, int *);
 extern int os_perf_init(void);
 extern void os_perf_fini(void);
 extern void os_perfthr_quit_wait(void);
-extern int os_perf_profiling_partpause(count_id_t);
-extern int os_perf_profiling_restore(count_id_t);
+extern int os_perf_profiling_partpause(perf_count_id_t);
+extern int os_perf_profiling_multipause(perf_count_id_t *);
+extern int os_perf_profiling_restore(perf_count_id_t);
+extern int os_perf_profiling_multi_restore(perf_count_id_t *);
 extern int os_perf_callchain_start(pid_t, int);
 extern int os_perf_callchain_smpl(void);
 extern int os_perf_ll_smpl(struct _perf_ctl *, pid_t, int);

--- a/common/include/os/pfwrapper.h
+++ b/common/include/os/pfwrapper.h
@@ -74,7 +74,7 @@ extern "C" {
 #endif
 
 typedef struct _pf_conf {
-	count_id_t count_id;
+	perf_count_id_t perf_count_id;
 	uint32_t type;
 	uint64_t config;
 	uint64_t config1;
@@ -95,7 +95,7 @@ typedef struct _pf_profiling_rbrec {
 	uint32_t tid;
 	uint64_t time_enabled;
 	uint64_t time_running;
-	uint64_t counts[COUNT_NUM];
+	uint64_t counts[PERF_COUNT_NUM];
 	uint64_t ip_num;
 } pf_profiling_rbrec_t;
 
@@ -126,8 +126,8 @@ typedef int (*pfn_pf_event_op_t)(struct _perf_cpu *);
 
 int pf_ringsize_init(void);
 int pf_profiling_setup(struct _perf_cpu *, int, pf_conf_t *);
-int pf_profiling_start(struct _perf_cpu *, count_id_t);
-int pf_profiling_stop(struct _perf_cpu *, count_id_t);
+int pf_profiling_start(struct _perf_cpu *, perf_count_id_t);
+int pf_profiling_stop(struct _perf_cpu *, perf_count_id_t);
 int pf_profiling_allstart(struct _perf_cpu *);
 int pf_profiling_allstop(struct _perf_cpu *);
 void pf_profiling_record(struct _perf_cpu *, pf_profiling_rec_t *, int *);

--- a/common/include/os/plat.h
+++ b/common/include/os/plat.h
@@ -56,11 +56,11 @@ typedef struct _plat_event_config {
 	char desc[PLAT_EVENT_DESC_SIZE];
 } plat_event_config_t;
 
-extern uint64_t g_sample_period[COUNT_NUM][PRECISE_NUM];
+extern uint64_t g_sample_period[PERF_COUNT_NUM][PRECISE_NUM];
 extern cpu_type_t s_cpu_type;
 extern boolean_t g_cmt_enabled;
 
-typedef void (*pfn_plat_profiling_config_t)(count_id_t,
+typedef void (*pfn_plat_profiling_config_t)(perf_count_id_t,
     plat_event_config_t *);
 typedef void (*pfn_plat_ll_config_t)(plat_event_config_t *);
 typedef int (*pfn_plat_offcore_num_t)(void);
@@ -70,9 +70,9 @@ extern pfn_plat_ll_config_t s_plat_ll_config[CPU_TYPE_NUM];
 extern pfn_plat_offcore_num_t s_plat_offcore_num[CPU_TYPE_NUM];
 
 extern int plat_detect(void);
-extern void plat_profiling_config(count_id_t, plat_event_config_t *);
+extern void plat_profiling_config(perf_count_id_t, plat_event_config_t *);
 extern void plat_ll_config(plat_event_config_t *);
-extern void plat_config_get(count_id_t, plat_event_config_t *, plat_event_config_t *);
+extern void plat_config_get(perf_count_id_t, plat_event_config_t *, plat_event_config_t *);
 extern int plat_offcore_num(void);
 
 #ifdef __cplusplus

--- a/common/include/perf.h
+++ b/common/include/perf.h
@@ -46,6 +46,7 @@ typedef enum {
 	PERF_STATUS_IDLE = 0,
 	PERF_STATUS_PROFILING_STARTED,
 	PERF_STATUS_PROFILING_PART_STARTED,
+	PERF_STATUS_PROFILING_MULTI_STARTED,
 	PERF_STATUS_PROFILING_FAILED,
 	PERF_STATUS_CALLCHAIN_STARTED,
 	PERF_STATUS_CALLCHAIN_FAILED,
@@ -61,7 +62,9 @@ typedef enum {
 	PERF_INVALID_ID = 0,
 	PERF_PROFILING_START_ID,
 	PERF_PROFILING_PARTPAUSE_ID,
+	PERF_PROFILING_MULTIPAUSE_ID,
 	PERF_PROFILING_RESTORE_ID,
+	PERF_PROFILING_MULTI_RESTORE_ID,
 	PERF_PROFILING_SMPL_ID,
 	PERF_CALLCHAIN_START_ID,
 	PERF_CALLCHAIN_SMPL_ID,
@@ -92,13 +95,23 @@ typedef struct _task_profiling {
 
 typedef struct _task_partpause {
 	perf_taskid_t task_id;
-	count_id_t count_id;
+	perf_count_id_t perf_count_id;
 } task_partpause_t;
+
+typedef struct _task_multipause {
+	perf_taskid_t task_id;
+	perf_count_id_t *perf_count_ids;
+} task_multipause_t;
 
 typedef struct _task_restore {
 	perf_taskid_t task_id;
-	count_id_t count_id;
+	perf_count_id_t perf_count_id;
 } task_restore_t;
+
+typedef struct _task_multi_restore {
+	perf_taskid_t task_id;
+	perf_count_id_t *perf_count_ids;
+} task_multi_restore_t;
 
 typedef struct _task_callchain {
 	perf_taskid_t task_id;
@@ -156,7 +169,7 @@ typedef struct _perf_chainrecgrp {
 } perf_chainrecgrp_t;
 
 typedef struct _perf_countchain {
-	perf_chainrecgrp_t chaingrps[COUNT_NUM];
+	perf_chainrecgrp_t chaingrps[PERF_COUNT_NUM];
 } perf_countchain_t;
 
 #define	TASKID(task_addr) \
@@ -187,8 +200,8 @@ extern int perf_allstop(void);
 extern boolean_t perf_profiling_started(void);
 extern int perf_profiling_start(void);
 extern int perf_profiling_smpl(boolean_t);
-extern int perf_profiling_partpause(count_id_t);
-extern int perf_profiling_restore(count_id_t);
+extern int perf_profiling_partpause(ui_count_id_t);
+extern int perf_profiling_restore(ui_count_id_t);
 extern boolean_t perf_callchain_started(void);
 extern int perf_callchain_start(pid_t, int);
 extern int perf_callchain_smpl(void);

--- a/common/include/proc.h
+++ b/common/include/proc.h
@@ -112,7 +112,7 @@ extern int proc_refcount_inc(track_proc_t *);
 extern void proc_refcount_dec(track_proc_t *);
 extern void proc_lwp_traverse(track_proc_t *,
 	int (*func)(track_lwp_t *, void *, boolean_t *), void *);
-extern int proc_countval_update(track_proc_t *, int, count_id_t, uint64_t);
+extern int proc_countval_update(track_proc_t *, int, perf_count_id_t, uint64_t);
 extern void proc_intval_update(int);
 extern int proc_intval_get(track_proc_t *);
 extern void proc_profiling_clear(void);

--- a/common/include/types.h
+++ b/common/include/types.h
@@ -105,7 +105,7 @@ typedef enum {
 
 #define COUNT_NUM		5
 #define	NNODES_MAX		64
-#define NCPUS_NODE_MAX	64
+#define NCPUS_NODE_MAX	128
 #define	NCPUS_MAX		(NNODES_MAX * NCPUS_NODE_MAX)
 #define NPROCS_NAX		4096
 #define	LL_THRESH		128

--- a/common/include/types.h
+++ b/common/include/types.h
@@ -29,7 +29,13 @@
 #ifndef _NUMATOP_TYPES_H
 #define	_NUMATOP_TYPES_H
 
+#include <stdint.h>
 #include "./os/os_types.h"
+#ifdef __powerpc64__
+#include "../../powerpc/include/types.h"
+#else
+#include "../../intel/include/types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,33 +83,37 @@ typedef enum {
 
 #define SMPL_PERIOD_INFINITE			0XFFFFFFFFFFFFFFULL
 #define SMPL_PERIOD_RMA_DEFAULT			10000
+#define SMPL_PERIOD_RMA_1_DEFAULT		10000
 #define SMPL_PERIOD_LMA_DEFAULT			10000
 #define SMPL_PERIOD_CLK_DEFAULT			10000000
 #define SMPL_PERIOD_CORECLK_DEFAULT		SMPL_PERIOD_INFINITE
 #define SMPL_PERIOD_IR_DEFAULT			10000000
 
 #define SMPL_PERIOD_RMA_MIN			5000
+#define SMPL_PERIOD_RMA_1_MIN			5000
 #define SMPL_PERIOD_LMA_MIN			5000
 #define SMPL_PERIOD_CLK_MIN			1000000
 #define SMPL_PERIOD_CORECLK_MIN			SMPL_PERIOD_INFINITE
 #define SMPL_PERIOD_IR_MIN			1000000
 
 #define SMPL_PERIOD_RMA_MAX			100000
+#define SMPL_PERIOD_RMA_1_MAX			100000
 #define SMPL_PERIOD_LMA_MAX			100000
 #define SMPL_PERIOD_CLK_MAX			100000000
 #define SMPL_PERIOD_CORECLK_MAX			SMPL_PERIOD_INFINITE
 #define SMPL_PERIOD_IR_MAX			100000000
 
 typedef enum {
-	COUNT_INVALID = -1,
-	COUNT_CORE_CLK = 0,
-	COUNT_RMA,
-	COUNT_CLK,
-	COUNT_IR,
-	COUNT_LMA
-} count_id_t;
+	UI_COUNT_INVALID = -1,
+	UI_COUNT_CORE_CLK = 0,
+	UI_COUNT_RMA,
+	UI_COUNT_CLK,
+	UI_COUNT_IR,
+	UI_COUNT_LMA
+} ui_count_id_t;
 
-#define COUNT_NUM		5
+#define UI_COUNT_NUM		5
+
 #define	NNODES_MAX		64
 #define NCPUS_NODE_MAX	128
 #define	NCPUS_MAX		(NNODES_MAX * NCPUS_NODE_MAX)
@@ -112,7 +122,7 @@ typedef enum {
 #define LL_PERIOD		1000
 
 typedef struct _count_value {
-	uint64_t counts[COUNT_NUM];
+	uint64_t counts[PERF_COUNT_NUM];
 } count_value_t;
 
 typedef struct _bufaddr {

--- a/common/include/ui_perf_map.h
+++ b/common/include/ui_perf_map.h
@@ -26,28 +26,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#ifndef _NUMATOP_UI_PERF_MAP_H
+#define _NUMATOP_UI_PERF_MAP_H
 
-#include "../../common/include/types.h"
+#include "types.h"
 
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8
-} cpu_type_t;
+/*
+ * Hardcoding 2 here because there is only one use case
+ * for powerpc and it uses 2 perf events to get RMA. If
+ * there is a case in future where more than 2 events are
+ * needed, this has to be changed.
+ */
+#define UI_PERF_MAP_MAX		2
 
-#define CPU_TYPE_NUM    2
+typedef struct _ui_perf_count_map_t {
+	ui_count_id_t ui_count_id;
+	int n_perf_count;
+	perf_count_id_t perf_count_ids[UI_PERF_MAP_MAX];
+} ui_perf_count_map_t;
 
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
+extern ui_perf_count_map_t ui_perf_count_map[UI_COUNT_NUM];
 
-#define PERF_COUNT_NUM	6
+extern int get_ui_perf_count_map(ui_count_id_t, perf_count_id_t **);
+extern uint64_t ui_perf_count_aggr(ui_count_id_t, uint64_t *);
 
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+#endif /* _NUMATOP_UI_PERF_MAP_H */

--- a/common/include/util.h
+++ b/common/include/util.h
@@ -94,6 +94,7 @@ extern void stderr_print(char *format, ...);
 extern int array_alloc(void **, int *, int *, int, int);
 extern void pagesize_init(void);
 extern uint64_t rdtsc(void);
+extern int arch__cpuinfo_freq(double *freq, char *unit);
 
 #ifdef __cplusplus
 }

--- a/common/include/win.h
+++ b/common/include/win.h
@@ -312,7 +312,7 @@ typedef struct _dyn_nodedetail {
 typedef struct _dyn_callchain {
 	pid_t pid;
 	int lwpid;
-	count_id_t countid;
+	ui_count_id_t ui_countid;
 	win_reg_t msg;
 	win_reg_t caption;
 	win_reg_t pad;

--- a/common/lwp.c
+++ b/common/lwp.c
@@ -278,10 +278,10 @@ lwp_refcount_dec(track_lwp_t *lwp)
 }
 
 static uint64_t
-count_value_get(track_lwp_t *lwp, count_id_t count_id)
+count_value_get(track_lwp_t *lwp, ui_count_id_t ui_count_id)
 {
 	return (node_countval_sum(lwp->countval_arr, lwp->cpuid_max,
-	    NODE_ALL, count_id));
+	    NODE_ALL, ui_count_id));
 }
 
 /*
@@ -294,7 +294,7 @@ lwp_key_compute(track_lwp_t *lwp, void *arg, boolean_t *end)
 
 	switch (sortkey) {
 	case SORT_KEY_CPU:
-		lwp->key = count_value_get(lwp, COUNT_CLK);
+		lwp->key = count_value_get(lwp, UI_COUNT_CLK);
 		break;
 
 	default:
@@ -309,7 +309,7 @@ lwp_key_compute(track_lwp_t *lwp, void *arg, boolean_t *end)
  * Update the lwp's per CPU perf data.
  */
 int
-lwp_countval_update(track_lwp_t *lwp, int cpu, count_id_t count_id,
+lwp_countval_update(track_lwp_t *lwp, int cpu, perf_count_id_t perf_count_id,
     uint64_t value)
 {
 	count_value_t *countval, *arr_new;
@@ -333,7 +333,7 @@ lwp_countval_update(track_lwp_t *lwp, int cpu, count_id_t count_id,
 	}
 
 	countval = &lwp->countval_arr[cpu];
-	countval->counts[count_id] += value;
+	countval->counts[perf_count_id] += value;
 	return (0);
 }
 

--- a/common/os/node.c
+++ b/common/os/node.c
@@ -39,6 +39,7 @@
 #include "../include/types.h"
 #include "../include/numatop.h"
 #include "../include/util.h"
+#include "../include/ui_perf_map.h"
 #include "../include/os/os_util.h"
 #include "../include/os/pfwrapper.h"
 #include "../include/os/node.h"
@@ -338,18 +339,18 @@ node_intval_get(void)
  * Update the node's perf data.
  */
 void
-node_countval_update(node_t *node, count_id_t count_id, uint64_t value)
+node_countval_update(node_t *node, perf_count_id_t perf_count_id, uint64_t value)
 {
-	node->countval.counts[count_id] += value;
+	node->countval.counts[perf_count_id] += value;
 }
 
 /*
  * Return the perf data of specified node and count.
  */
 uint64_t
-node_countval_get(node_t *node, count_id_t count_id)
+node_countval_get(node_t *node, ui_count_id_t ui_count_id)
 {
-	return (node->countval.counts[count_id]);
+	return (ui_perf_count_aggr(ui_count_id, node->countval.counts));
 }
 
 /*
@@ -417,7 +418,7 @@ node_cpu_traverse(pfn_perf_cpu_op_t func, void *arg, boolean_t err_ret,
 
 static uint64_t
 countval_sum(count_value_t *countval_arr, int cpuid_max, int nid,
-	count_id_t count_id)
+	ui_count_id_t ui_count_id)
 {
 	uint64_t value = 0;
 	node_t *node;
@@ -434,7 +435,8 @@ countval_sum(count_value_t *countval_arr, int cpuid_max, int nid,
 		}
 
 		if ((cpuid = node->cpus[i].cpuid) != INVALID_CPUID) {
-			value += countval_arr[cpuid].counts[count_id];
+			value += ui_perf_count_aggr(ui_count_id,
+					countval_arr[cpuid].counts);
 			num++;
 		}
 	}
@@ -444,17 +446,17 @@ countval_sum(count_value_t *countval_arr, int cpuid_max, int nid,
 
 uint64_t
 node_countval_sum(count_value_t *countval_arr, int cpuid_max, int nid,
-	count_id_t count_id)
+	ui_count_id_t ui_count_id)
 {
 	int i;
 	uint64_t value = 0;
 
 	if (nid != NODE_ALL) {
-		return (countval_sum(countval_arr, cpuid_max, nid, count_id));
+		return (countval_sum(countval_arr, cpuid_max, nid, ui_count_id));
 	}
 
 	for (i = 0; i < NNODES_MAX; i++) {
-		value += countval_sum(countval_arr, cpuid_max, i, count_id);
+		value += countval_sum(countval_arr, cpuid_max, i, ui_count_id);
 	}
 
 	return (value);

--- a/common/os/os_cmd.c
+++ b/common/os/os_cmd.c
@@ -42,11 +42,11 @@
 #include "../include/os/map.h"
 #include "../include/os/os_cmd.h"
 
-static int s_callchain_countid[] = {
-	COUNT_RMA,
-	COUNT_LMA,
-	COUNT_CLK,
-	COUNT_IR
+static int s_callchain_ui_countid[] = {
+	UI_COUNT_RMA,
+	UI_COUNT_LMA,
+	UI_COUNT_CLK,
+	UI_COUNT_IR
 };
 
 /* ARGSUSED */
@@ -162,7 +162,7 @@ os_preop_switch2callchain(cmd_t *cmd, boolean_t *smpl)
 	}	
 
 	*smpl = B_TRUE;
-	return (perf_profiling_partpause(COUNT_RMA));
+	return (perf_profiling_partpause(UI_COUNT_RMA));
 }
 
 int
@@ -193,14 +193,14 @@ int
 os_preop_leavecallchain(cmd_t *cmd, boolean_t *smpl)
 {
 	page_t *cur = page_current_get();
-	count_id_t countid;
-	
-	if ((countid = DYN_CALLCHAIN(cur)->countid) != 0) {		
-		perf_profiling_restore(countid);
+	ui_count_id_t ui_countid;
+
+	if ((ui_countid = DYN_CALLCHAIN(cur)->ui_countid) != 0) {
+		perf_profiling_restore(ui_countid);
 	}
 
 	*smpl = B_TRUE;
-	return (0);	
+	return (0);
 }
 
 int
@@ -347,34 +347,35 @@ os_op_switch2ll(cmd_t *cmd, boolean_t smpl)
 	return (op_page_next(cmd, smpl));
 }
 
-static count_id_t
+static ui_count_id_t
 callchain_countid_set(int cmd_id, page_t *page)
 {
 	dyn_callchain_t *dyn = (dyn_callchain_t *)(page->dyn_win.dyn);
 
 	if ((cmd_id >= CMD_1_ID) && (cmd_id <= CMD_4_ID)) {
-		dyn->countid = s_callchain_countid[cmd_id - CMD_1_ID];
+		dyn->ui_countid = s_callchain_ui_countid[cmd_id - CMD_1_ID];
 	} else {
-		dyn->countid = COUNT_INVALID;
+		dyn->ui_countid = UI_COUNT_INVALID;
 	}
 
-	return (dyn->countid);
+	return (dyn->ui_countid);
 }
 
 int
 os_op_callchain_count(cmd_t *cmd, boolean_t smpl)
 {
 	page_t *cur;
-	count_id_t countid;
+	ui_count_id_t ui_countid;
 	int cmd_id;
 
 	if ((cur = page_current_get()) != NULL) {
 		cmd_id = CMD_ID(cmd);
-		if ((countid = callchain_countid_set(cmd_id, cur)) == COUNT_INVALID) {
+		ui_countid = callchain_countid_set(cmd_id, cur);
+		if (ui_countid == UI_COUNT_INVALID) {
 			return (0);	
 		}
 
-		perf_profiling_partpause(countid);
+		perf_profiling_partpause(ui_countid);
 		op_refresh(cmd, smpl);
 	}
 

--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -168,33 +168,12 @@ processor_unbind(void)
 static int
 calibrate_cpuinfo(double *nsofclk, uint64_t *clkofsec)
 {
-	FILE *f;
-	char *line = NULL, unit[11];
-	size_t len = 0;
+	char unit[11] = {0};
 	double freq = 0.0;
 
-	if ((f = fopen(CPUINFO_PATH, "r")) == NULL) {
-		return (-1);
+	if (arch__cpuinfo_freq(&freq, unit)) {
+		return -1;
 	}
-
-	while (getline(&line, &len, f) > 0) {
-		if (strncmp(line, "model name", sizeof ("model name") - 1) != 0) {
-	    		continue;
-		}
-
-		if (sscanf(line + strcspn(line, "@") + 1, "%lf%10s",
-			&freq, unit) == 2) {
-			if (strcasecmp(unit, "GHz") == 0) {
-				freq *= GHZ;
-			} else if (strcasecmp(unit, "Mhz") == 0) {
-				freq *= MHZ;				
-			}
-			break;
-		}
-	}
-
-	free(line);
-	fclose(f);
 
 	if (fabsl(freq) < 1.0E-6) {
 		return (-1);

--- a/common/os/os_win.c
+++ b/common/os/os_win.c
@@ -45,6 +45,7 @@
 #include "../include/page.h"
 #include "../include/perf.h"
 #include "../include/win.h"
+#include "../include/ui_perf_map.h"
 #include "../include/os/node.h"
 #include "../include/os/os_perf.h"
 #include "../include/os/os_util.h"
@@ -408,7 +409,9 @@ os_callchain_list_show(dyn_callchain_t *dyn, track_proc_t *proc,
 	sym_chainlist_t chainlist;
 	win_reg_t *reg;
 	char content[WIN_LINECHAR_MAX];
-	int i;
+	int i, j;
+	int n_perf_count;
+	perf_count_id_t *perf_count_ids = NULL;
 
 	reg = &dyn->caption;
 	reg_erase(reg);	
@@ -435,12 +438,17 @@ os_callchain_list_show(dyn_callchain_t *dyn, track_proc_t *proc,
 	}
 
 	memset(&chainlist, 0, sizeof (sym_chainlist_t));
-	rec_grp = &count_chain->chaingrps[dyn->countid];
-	rec_arr = rec_grp->rec_arr;
 
-	for (i = 0; i < rec_grp->nrec_cur; i++) {
-		sym_callchain_add(&proc->sym, rec_arr[i].callchain.ips,
-			rec_arr[i].callchain.ip_num, &chainlist);		
+	n_perf_count = get_ui_perf_count_map(dyn->ui_countid, &perf_count_ids);
+
+	for (i = 0; i < n_perf_count; i++) {
+		rec_grp = &count_chain->chaingrps[perf_count_ids[i]];
+		rec_arr = rec_grp->rec_arr;
+
+		for (j = 0; j < rec_grp->nrec_cur; j++) {
+			sym_callchain_add(&proc->sym, rec_arr[j].callchain.ips,
+				rec_arr[j].callchain.ip_num, &chainlist);
+		}
 	}
 
 	chainlist_show(&chainlist, &dyn->data);

--- a/common/os/pfwrapper.c
+++ b/common/os/pfwrapper.c
@@ -208,20 +208,20 @@ pf_profiling_setup(struct _perf_cpu *cpu, int idx, pf_conf_t *conf)
 }
 
 int
-pf_profiling_start(struct _perf_cpu *cpu, count_id_t count_id)
+pf_profiling_start(struct _perf_cpu *cpu, perf_count_id_t perf_count_id)
 {
-	if (cpu->fds[count_id] != INVALID_FD) {
-		return (ioctl(cpu->fds[count_id], PERF_EVENT_IOC_ENABLE, 0));
+	if (cpu->fds[perf_count_id] != INVALID_FD) {
+		return (ioctl(cpu->fds[perf_count_id], PERF_EVENT_IOC_ENABLE, 0));
 	}
 	
 	return (0);
 }
 
 int
-pf_profiling_stop(struct _perf_cpu *cpu, count_id_t count_id)
+pf_profiling_stop(struct _perf_cpu *cpu, perf_count_id_t perf_count_id)
 {
-	if (cpu->fds[count_id] != INVALID_FD) {
-		return (ioctl(cpu->fds[count_id], PERF_EVENT_IOC_DISABLE, 0));
+	if (cpu->fds[perf_count_id] != INVALID_FD) {
+		return (ioctl(cpu->fds[perf_count_id], PERF_EVENT_IOC_DISABLE, 0));
 	}
 	
 	return (0);
@@ -625,7 +625,7 @@ pf_resource_free(struct _perf_cpu *cpu)
 {
 	int i;
 
-	for (i = 0; i < COUNT_NUM; i++) {
+	for (i = 0; i < PERF_COUNT_NUM; i++) {
 		if (cpu->fds[i] != INVALID_FD) {
 			close(cpu->fds[i]);
 			cpu->fds[i] = INVALID_FD;

--- a/common/os/plat.c
+++ b/common/os/plat.c
@@ -46,13 +46,13 @@ boolean_t g_cmt_enabled = B_FALSE;
  * Platform-independent function to get the event configuration for profiling.
  */
 void
-plat_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+plat_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
 	pfn_plat_profiling_config_t pfn =
 	    s_plat_profiling_config[s_cpu_type];
 
 	if (pfn != NULL) {
-		pfn(count_id, cfg);
+		pfn(perf_count_id, cfg);
 	}
 }
 
@@ -71,14 +71,14 @@ plat_ll_config(plat_event_config_t *cfg)
 }
 
 void
-plat_config_get(count_id_t count_id, plat_event_config_t *cfg,
+plat_config_get(perf_count_id_t perf_count_id, plat_event_config_t *cfg,
 	plat_event_config_t *cfg_arr)
 {
-	cfg->type = cfg_arr[count_id].type;
-	cfg->config = cfg_arr[count_id].config;
-	cfg->other_attr = cfg_arr[count_id].other_attr;
-	cfg->extra_value = cfg_arr[count_id].extra_value;
-	strncpy(cfg->desc, cfg_arr[count_id].desc, PLAT_EVENT_DESC_SIZE);
+	cfg->type = cfg_arr[perf_count_id].type;
+	cfg->config = cfg_arr[perf_count_id].config;
+	cfg->other_attr = cfg_arr[perf_count_id].other_attr;
+	cfg->extra_value = cfg_arr[perf_count_id].extra_value;
+	strncpy(cfg->desc, cfg_arr[perf_count_id].desc, PLAT_EVENT_DESC_SIZE);
 	cfg->desc[PLAT_EVENT_DESC_SIZE - 1] = 0;
 }
 

--- a/common/proc.c
+++ b/common/proc.c
@@ -413,10 +413,10 @@ proc_group_unlock(void)
 }
 
 static uint64_t
-count_value_get(track_proc_t *proc, count_id_t count_id)
+count_value_get(track_proc_t *proc, ui_count_id_t ui_count_id)
 {
 	return (node_countval_sum(proc->countval_arr, proc->cpuid_max,
-	    NODE_ALL, count_id));
+	    NODE_ALL, ui_count_id));
 }
 
 /*
@@ -431,7 +431,7 @@ proc_key_compute(track_proc_t *proc, void *arg, boolean_t *end)
 
 	switch (sortkey) {
 	case SORT_KEY_CPU:
-		proc->key = count_value_get(proc, COUNT_CLK);
+		proc->key = count_value_get(proc, UI_COUNT_CLK);
 		break;
 
 	case SORT_KEY_PID:
@@ -439,34 +439,34 @@ proc_key_compute(track_proc_t *proc, void *arg, boolean_t *end)
 		break;
 
 	case SORT_KEY_RPI:
-		rma = count_value_get(proc, COUNT_RMA);
-		ir = count_value_get(proc, COUNT_IR);
+		rma = count_value_get(proc, UI_COUNT_RMA);
+		ir = count_value_get(proc, UI_COUNT_IR);
 		proc->key = (uint64_t)ratio(rma * 1000, ir);
 		break;
 
 	case SORT_KEY_LPI:
-		lma = count_value_get(proc, COUNT_LMA);
-		ir = count_value_get(proc, COUNT_IR);
+		lma = count_value_get(proc, UI_COUNT_LMA);
+		ir = count_value_get(proc, UI_COUNT_IR);
 		proc->key = (uint64_t)ratio(lma * 1000, ir);
 		break;
 
 	case SORT_KEY_CPI:
-		clk = count_value_get(proc, COUNT_CLK);
-		ir = count_value_get(proc, COUNT_IR);
+		clk = count_value_get(proc, UI_COUNT_CLK);
+		ir = count_value_get(proc, UI_COUNT_IR);
 		proc->key = (uint64_t)ratio(clk * 1000, ir);
 		break;
 
 	case SORT_KEY_RMA:
-		proc->key = count_value_get(proc, COUNT_RMA);
+		proc->key = count_value_get(proc, UI_COUNT_RMA);
 		break;
 
 	case SORT_KEY_LMA:
-		proc->key = count_value_get(proc, COUNT_LMA);
+		proc->key = count_value_get(proc, UI_COUNT_LMA);
 		break;
 
 	case SORT_KEY_RL:
-		rma = count_value_get(proc, COUNT_RMA);
-		lma = count_value_get(proc, COUNT_LMA);
+		rma = count_value_get(proc, UI_COUNT_RMA);
+		lma = count_value_get(proc, UI_COUNT_LMA);
 		proc->key = (uint64_t)ratio(rma * 1000, lma);
 		break;
 
@@ -863,7 +863,7 @@ proc_lwp_traverse(track_proc_t *proc,
  * Update the process's per CPU perf data.
  */
 int
-proc_countval_update(track_proc_t *proc, int cpu, count_id_t count_id,
+proc_countval_update(track_proc_t *proc, int cpu, perf_count_id_t perf_count_id,
     uint64_t value)
 {
 	count_value_t *countval, *arr_new;
@@ -887,7 +887,7 @@ proc_countval_update(track_proc_t *proc, int cpu, count_id_t count_id,
 	}
 
 	countval = &proc->countval_arr[cpu];
-	countval->counts[count_id] += value;
+	countval->counts[perf_count_id] += value;
 	return (0);
 }
 

--- a/common/ui_perf_map.c
+++ b/common/ui_perf_map.c
@@ -26,28 +26,33 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#include <stddef.h>
+#include "./include/types.h"
+#include "./include/ui_perf_map.h"
 
-#include "../../common/include/types.h"
+int
+get_ui_perf_count_map(ui_count_id_t ui_count_id, perf_count_id_t **perf_count_ids)
+{
+	if (ui_count_id == UI_COUNT_INVALID) {
+		return PERF_COUNT_INVALID;
+	}
 
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8
-} cpu_type_t;
+	*perf_count_ids = ui_perf_count_map[ui_count_id].perf_count_ids;
+	return ui_perf_count_map[ui_count_id].n_perf_count;
+}
 
-#define CPU_TYPE_NUM    2
+uint64_t
+ui_perf_count_aggr(ui_count_id_t ui_count_id, uint64_t *counts)
+{
+	int i = 0;
+	uint64_t tmp = 0;
+	int n_perf_count;
+	perf_count_id_t *perf_count_ids = NULL;
 
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
+	n_perf_count = get_ui_perf_count_map(ui_count_id, &perf_count_ids);
 
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+	for (i = 0; i < n_perf_count; i++) {
+		tmp += counts[perf_count_ids[i]];
+	}
+	return tmp;
+}

--- a/common/win.c
+++ b/common/win.c
@@ -329,10 +329,10 @@ win_countvalue_fill(win_countvalue_t *cv,
 	uint64_t rma, lma, ir, clk, all_clks;
 	double d;
 
-	rma = node_countval_sum(countval_arr, cpuid_max, nid, COUNT_RMA);
-	lma = node_countval_sum(countval_arr, cpuid_max, nid, COUNT_LMA);
-	clk = node_countval_sum(countval_arr, cpuid_max, nid, COUNT_CLK);
-	ir = node_countval_sum(countval_arr, cpuid_max, nid, COUNT_IR);
+	rma = node_countval_sum(countval_arr, cpuid_max, nid, UI_COUNT_RMA);
+	lma = node_countval_sum(countval_arr, cpuid_max, nid, UI_COUNT_LMA);
+	clk = node_countval_sum(countval_arr, cpuid_max, nid, UI_COUNT_CLK);
+	ir = node_countval_sum(countval_arr, cpuid_max, nid, UI_COUNT_IR);
 
 	cv->rpi = ratio(rma * 1000, ir);
 	cv->lpi = ratio(lma * 1000, ir);
@@ -1540,10 +1540,10 @@ win_node_countvalue(node_t *node, win_countvalue_t *cv)
 	double d;
 	uint64_t rma, lma, clk, ir, all_clks;
 
-	rma = node_countval_get(node, COUNT_RMA);
-	lma = node_countval_get(node, COUNT_LMA);
-	clk = node_countval_get(node, COUNT_CLK);
-	ir = node_countval_get(node, COUNT_IR);
+	rma = node_countval_get(node, UI_COUNT_RMA);
+	lma = node_countval_get(node, UI_COUNT_LMA);
+	clk = node_countval_get(node, UI_COUNT_CLK);
+	ir = node_countval_get(node, UI_COUNT_IR);
 
 	cv->rpi = ratio(rma * 1000, ir);
 	cv->lpi = ratio(lma * 1000, ir);
@@ -1861,7 +1861,7 @@ callchain_dyn_create(page_t *page)
 
 	dyn->pid = cmd_callchain->pid;
 	dyn->lwpid = cmd_callchain->lwpid;
-	dyn->countid = COUNT_RMA;
+	dyn->ui_countid = UI_COUNT_RMA;
 
 	if ((i = reg_init(&dyn->msg, 0, 1, g_scr_width, 2, A_BOLD)) < 0)
 		goto L_EXIT;
@@ -1905,22 +1905,22 @@ callchain_win_destroy(dyn_win_t *win)
 }
 
 static void
-callchain_event_name(count_id_t count_id, char *buf, int size)
+callchain_event_name(ui_count_id_t ui_count_id, char *buf, int size)
 {
-	switch (count_id) {
-	case COUNT_RMA:
+	switch (ui_count_id) {
+	case UI_COUNT_RMA:
 		(void) strncpy(buf, "RMA", size);
 		break;
 
-	case COUNT_CLK:
+	case UI_COUNT_CLK:
 		(void) strncpy(buf, "Cycle", size);
 		break;
 
-	case COUNT_IR:
+	case UI_COUNT_IR:
 		(void) strncpy(buf, "IR", size);
 		break;
 
-	case COUNT_LMA:
+	case UI_COUNT_LMA:
 		(void) strncpy(buf, "LMA", size);
 		break;
 
@@ -1960,7 +1960,7 @@ callchain_data_show(dyn_win_t *win, boolean_t *note_out)
 
 	r = &dyn->msg;
 	reg_erase(r);
-	callchain_event_name(dyn->countid, event_name, 32);
+	callchain_event_name(dyn->ui_countid, event_name, 32);
 	disp_intval(intval_buf, 16);
 	if (lwpid == 0) {
 		(void) snprintf(content, WIN_LINECHAR_MAX,

--- a/intel/bdw.c
+++ b/intel/bdw.c
@@ -39,7 +39,7 @@
 #include "../common/include/os/plat.h"
 #include "include/bdw.h"
 
-static plat_event_config_t s_bdw_config[COUNT_NUM] = {
+static plat_event_config_t s_bdw_config[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
 	{ PERF_TYPE_RAW, 0x01B7, 0x53, 0x638000001, "off_core_response_0" },
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
@@ -52,9 +52,9 @@ static plat_event_config_t s_bdw_ll = {
 };
 
 void
-bdw_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+bdw_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	plat_config_get(count_id, cfg, s_bdw_config);
+	plat_config_get(perf_count_id, cfg, s_bdw_config);
 }
 
 void

--- a/intel/include/bdw.h
+++ b/intel/include/bdw.h
@@ -39,7 +39,7 @@ extern "C" {
 
 struct _plat_event_config;
 
-extern void bdw_profiling_config(count_id_t, struct _plat_event_config *);
+extern void bdw_profiling_config(perf_count_id_t, struct _plat_event_config *);
 extern void bdw_ll_config(struct _plat_event_config *);
 extern int bdw_offcore_num(void);
 

--- a/intel/include/nhm.h
+++ b/intel/include/nhm.h
@@ -39,8 +39,8 @@ extern "C" {
 
 struct _plat_event_config;
 
-extern void nhmex_profiling_config(count_id_t, struct _plat_event_config *);
-extern void nhmep_profiling_config(count_id_t, struct _plat_event_config *);
+extern void nhmex_profiling_config(perf_count_id_t, struct _plat_event_config *);
+extern void nhmep_profiling_config(perf_count_id_t, struct _plat_event_config *);
 extern void nhmex_ll_config(struct _plat_event_config *);
 extern void nhmep_ll_config(struct _plat_event_config *);
 extern int nhm_offcore_num(void);

--- a/intel/include/skl.h
+++ b/intel/include/skl.h
@@ -39,7 +39,7 @@ extern "C" {
 
 struct _plat_event_config;
 
-extern void skl_profiling_config(count_id_t, struct _plat_event_config *);
+extern void skl_profiling_config(perf_count_id_t, struct _plat_event_config *);
 extern void skl_ll_config(struct _plat_event_config *);
 extern int skl_offcore_num(void);
 

--- a/intel/include/snb.h
+++ b/intel/include/snb.h
@@ -39,7 +39,7 @@ extern "C" {
 
 struct _plat_event_config;
 
-extern void snbep_profiling_config(count_id_t, struct _plat_event_config *);
+extern void snbep_profiling_config(perf_count_id_t, struct _plat_event_config *);
 extern void snbep_ll_config(struct _plat_event_config *);
 extern int snb_offcore_num(void);
 

--- a/intel/include/types.h
+++ b/intel/include/types.h
@@ -30,6 +30,8 @@
 #ifndef _NUMATOP_INTEL_TYPES_H
 #define _NUMATOP_INTEL_TYPES_H
 
+#include "../../common/include/types.h"
+
 typedef enum {
 	CPU_UNSUP = 0,
 	CPU_WSM_EX,
@@ -44,5 +46,16 @@ typedef enum {
 } cpu_type_t;
 
 #define	CPU_TYPE_NUM	10
+
+typedef enum {
+	PERF_COUNT_INVALID = -1,
+	PERF_COUNT_CORE_CLK = 0,
+	PERF_COUNT_RMA,
+	PERF_COUNT_CLK,
+	PERF_COUNT_IR,
+	PERF_COUNT_LMA
+} perf_count_id_t;
+
+#define PERF_COUNT_NUM		5
 
 #endif /* _NUMATOP_INTEL_TYPES_H */

--- a/intel/include/wsm.h
+++ b/intel/include/wsm.h
@@ -39,8 +39,8 @@ extern "C" {
 
 struct _plat_event_config;
 
-extern void wsmex_profiling_config(count_id_t, struct _plat_event_config *);
-extern void wsmep_profiling_config(count_id_t, struct _plat_event_config *);
+extern void wsmex_profiling_config(perf_count_id_t, struct _plat_event_config *);
+extern void wsmep_profiling_config(perf_count_id_t, struct _plat_event_config *);
 extern void wsmex_ll_config(struct _plat_event_config *);
 extern void wsmep_ll_config(struct _plat_event_config *);
 extern int wsm_offcore_num(void);

--- a/intel/nhm.c
+++ b/intel/nhm.c
@@ -40,7 +40,7 @@
 #include "../common/include/os/os_perf.h"
 #include "include/nhm.h"
 
-static plat_event_config_t s_nhm_profiling[COUNT_NUM] = {
+static plat_event_config_t s_nhm_profiling[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
 	{ PERF_TYPE_RAW, 0x01B7, 0x53, 0x2011, "off_core_response_0" },
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
@@ -53,26 +53,26 @@ static plat_event_config_t s_nhm_ll = {
 };
 
 static void
-config_get(count_id_t count_id, plat_event_config_t *cfg, plat_event_config_t *cfg_arr)
+config_get(perf_count_id_t perf_count_id, plat_event_config_t *cfg, plat_event_config_t *cfg_arr)
 {
-	cfg->type = cfg_arr[count_id].type;
-	cfg->config = cfg_arr[count_id].config;
-	cfg->other_attr = cfg_arr[count_id].other_attr;
-	cfg->extra_value = cfg_arr[count_id].extra_value;
-	strncpy(cfg->desc, cfg_arr[count_id].desc, PLAT_EVENT_DESC_SIZE);
+	cfg->type = cfg_arr[perf_count_id].type;
+	cfg->config = cfg_arr[perf_count_id].config;
+	cfg->other_attr = cfg_arr[perf_count_id].other_attr;
+	cfg->extra_value = cfg_arr[perf_count_id].extra_value;
+	strncpy(cfg->desc, cfg_arr[perf_count_id].desc, PLAT_EVENT_DESC_SIZE);
 	cfg->desc[PLAT_EVENT_DESC_SIZE - 1] = 0;
 }
 
 void
-nhmex_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+nhmex_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	config_get(count_id, cfg, s_nhm_profiling);
+	config_get(perf_count_id, cfg, s_nhm_profiling);
 }
 
 void
-nhmep_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+nhmep_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	config_get(count_id, cfg, s_nhm_profiling);
+	config_get(perf_count_id, cfg, s_nhm_profiling);
 }
 
 void

--- a/intel/skl.c
+++ b/intel/skl.c
@@ -39,7 +39,7 @@
 #include "../common/include/os/plat.h"
 #include "include/skl.h"
 
-static plat_event_config_t s_skl_config[COUNT_NUM] = {
+static plat_event_config_t s_skl_config[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
 	{ PERF_TYPE_RAW, 0x01B7, 0x53, 0x638000001, "off_core_response_0" },
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
@@ -52,9 +52,9 @@ static plat_event_config_t s_skl_ll = {
 };
 
 void
-skl_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+skl_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	plat_config_get(count_id, cfg, s_skl_config);
+	plat_config_get(perf_count_id, cfg, s_skl_config);
 }
 
 void

--- a/intel/snb.c
+++ b/intel/snb.c
@@ -39,7 +39,7 @@
 #include "../common/include/os/plat.h"
 #include "include/snb.h"
 
-static plat_event_config_t s_snb_ep_config[COUNT_NUM] = {
+static plat_event_config_t s_snb_ep_config[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
 	{ PERF_TYPE_RAW, 0x01B7, 0x53, 0x67f800001, "off_core_response_0" },
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
@@ -52,9 +52,9 @@ static plat_event_config_t s_snb_ll = {
 };
 
 void
-snbep_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+snbep_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	plat_config_get(count_id, cfg, s_snb_ep_config);
+	plat_config_get(perf_count_id, cfg, s_snb_ep_config);
 }
 
 void

--- a/intel/ui_perf_map.c
+++ b/intel/ui_perf_map.c
@@ -26,28 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#include "../common/include/ui_perf_map.h"
 
-#include "../../common/include/types.h"
-
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8
-} cpu_type_t;
-
-#define CPU_TYPE_NUM    2
-
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
-
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+ui_perf_count_map_t ui_perf_count_map[UI_COUNT_NUM] = {
+	{ UI_COUNT_CORE_CLK, 0, { PERF_COUNT_INVALID, PERF_COUNT_INVALID } },
+	{ UI_COUNT_RMA,      1, { PERF_COUNT_RMA, PERF_COUNT_INVALID }     },
+	{ UI_COUNT_CLK,      1, { PERF_COUNT_CLK, PERF_COUNT_INVALID }     },
+	{ UI_COUNT_IR,       1, { PERF_COUNT_IR, PERF_COUNT_INVALID }      },
+	{ UI_COUNT_LMA,      1, { PERF_COUNT_LMA, PERF_COUNT_INVALID }     }
+};

--- a/intel/wsm.c
+++ b/intel/wsm.c
@@ -39,7 +39,7 @@
 #include "../common/include/os/plat.h"
 #include "include/wsm.h"
 
-static plat_event_config_t s_wsmex_profiling[COUNT_NUM] = {
+static plat_event_config_t s_wsmex_profiling[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
 	{ PERF_TYPE_RAW, 0x01B7, 0x53, 0x2011, "off_core_response_0" },
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
@@ -47,7 +47,7 @@ static plat_event_config_t s_wsmex_profiling[COUNT_NUM] = {
 	{ PERF_TYPE_RAW, 0x01BB, 0x53, 0x5011, "off_core_response_1" }
 };
 
-static plat_event_config_t s_wsmep_profiling[COUNT_NUM] = {
+static plat_event_config_t s_wsmep_profiling[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
 	{ PERF_TYPE_RAW, 0x01B7, 0x53, 0x2011, "off_core_response_0" },
 	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
@@ -60,15 +60,15 @@ static plat_event_config_t s_wsm_ll = {
 };
 
 void
-wsmex_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+wsmex_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	plat_config_get(count_id, cfg, s_wsmex_profiling);
+	plat_config_get(perf_count_id, cfg, s_wsmex_profiling);
 }
 
 void
-wsmep_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+wsmep_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	plat_config_get(count_id, cfg, s_wsmep_profiling);
+	plat_config_get(perf_count_id, cfg, s_wsmep_profiling);
 }
 
 void

--- a/powerpc/FEATURES
+++ b/powerpc/FEATURES
@@ -1,0 +1,46 @@
+Features supported on PowerPC:
+------------------------------
+
+Per process/thread:
+
+| Feature                                                   | Supported     |
+|-----------------------------------------------------------|---------------|
+| RMA (RMEM + DMEM)                                         | Y (only DMEM) |
+| LMA (LMEM)                                                | Y             |
+| CPI                                                       | Y             |
+| CPU%                                                      | Y (only Host) |
+| Memory area ADDR                                          | Y             |
+| Memory area SIZE                                          | Y             |
+| Memory area ACCESS%                                       | N             |
+| Memory area LAT(ns)                                       | N             |
+| Memory area DESC                                          | Y             |
+| Node ACCESS%                                              | N             |
+| Node LAT(ns)                                              | N             |
+| Call-chain when process generates RMA / LMA / CYCLES / IR | Y             |
+| Call-chain when process accesses the memory area          | N             |
+| PQOS CMT/MBM                                              | N             |
+
+Per Node:
+
+| Feature                                                   | Supported     |
+|-----------------------------------------------------------|---------------|
+| RMA (RMEM + DMEM)                                         | Y (only DMEM) |
+| LMA (LMEM)                                                | Y             |
+| CPU                                                       | Y             |
+| CPU%                                                      | Y (only Host) |
+| MEM total                                                 | Y             |
+| MEM free                                                  | Y             |
+| MEM active                                                | Y             |
+| MEM inactive                                              | Y             |
+| Dirty                                                     | Y             |
+| Writeback                                                 | Y             |
+| Mapped                                                    | Y             |
+| QPI/UPI 0 bandwidth                                       | N             |
+| QPI/UPI 1 bandwidth                                       | N             |
+| Memory controller bandwidth                               | N             |
+
+Other:
+
+| Feature                                                   | Supported     |
+|-----------------------------------------------------------|---------------|
+| mgen testcase                                             | N             |

--- a/powerpc/FEATURES
+++ b/powerpc/FEATURES
@@ -8,7 +8,7 @@ Per process/thread:
 | RMA (RMEM + DMEM)                                         | Y (only DMEM) |
 | LMA (LMEM)                                                | Y             |
 | CPI                                                       | Y             |
-| CPU%                                                      | Y (only Host) |
+| CPU%                                                      | Y             |
 | Memory area ADDR                                          | Y             |
 | Memory area SIZE                                          | Y             |
 | Memory area ACCESS%                                       | N             |
@@ -27,7 +27,7 @@ Per Node:
 | RMA (RMEM + DMEM)                                         | Y (only DMEM) |
 | LMA (LMEM)                                                | Y             |
 | CPU                                                       | Y             |
-| CPU%                                                      | Y (only Host) |
+| CPU%                                                      | Y             |
 | MEM total                                                 | Y             |
 | MEM free                                                  | Y             |
 | MEM active                                                | Y             |

--- a/powerpc/FEATURES
+++ b/powerpc/FEATURES
@@ -5,7 +5,7 @@ Per process/thread:
 
 | Feature                                                   | Supported     |
 |-----------------------------------------------------------|---------------|
-| RMA (RMEM + DMEM)                                         | Y (only DMEM) |
+| RMA (RMEM + DMEM)                                         | Y             |
 | LMA (LMEM)                                                | Y             |
 | CPI                                                       | Y             |
 | CPU%                                                      | Y             |
@@ -24,7 +24,7 @@ Per Node:
 
 | Feature                                                   | Supported     |
 |-----------------------------------------------------------|---------------|
-| RMA (RMEM + DMEM)                                         | Y (only DMEM) |
+| RMA (RMEM + DMEM)                                         | Y             |
 | LMA (LMEM)                                                | Y             |
 | CPU                                                       | Y             |
 | CPU%                                                      | Y             |

--- a/powerpc/include/power8.h
+++ b/powerpc/include/power8.h
@@ -39,7 +39,7 @@ extern "C" {
 
 struct _plat_event_config;
 
-extern void power8_profiling_config(count_id_t, struct _plat_event_config *);
+extern void power8_profiling_config(perf_count_id_t, struct _plat_event_config *);
 extern void power8_ll_config(plat_event_config_t *cfg);
 extern int power8_offcore_num(void);
 

--- a/powerpc/power8.c
+++ b/powerpc/power8.c
@@ -37,12 +37,13 @@
 #include "../common/include/os/plat.h"
 #include "include/power8.h"
 
-static plat_event_config_t s_power8_profiling[COUNT_NUM] = {
+static plat_event_config_t s_power8_profiling[PERF_COUNT_NUM] = {
 	{ PERF_TYPE_RAW, 0x600f4, 0, 0, "PM_RUN_CYC" },
 	{ PERF_TYPE_RAW, 0x4c04c, 0, 0, "PM_DATA_FROM_DMEM" },
 	{ PERF_TYPE_RAW, 0x1001e, 0, 0, "PM_CYC" },
 	{ PERF_TYPE_RAW, 0x500fa, 0, 0, "PM_RUN_INST_CMPL" },
 	{ PERF_TYPE_RAW, 0x2c048, 0, 0, "PM_DATA_FROM_LMEM" },
+	{ PERF_TYPE_RAW, 0x3c04a, 0, 0, "PM_DATA_FROM_RMEM" },
 };
 
 static plat_event_config_t s_power8_ll = {
@@ -50,9 +51,9 @@ static plat_event_config_t s_power8_ll = {
 };
 
 void
-power8_profiling_config(count_id_t count_id, plat_event_config_t *cfg)
+power8_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
 {
-	plat_config_get(count_id, cfg, s_power8_profiling);
+	plat_config_get(perf_count_id, cfg, s_power8_profiling);
 }
 
 void
@@ -64,5 +65,5 @@ power8_ll_config(plat_event_config_t *cfg)
 int
 power8_offcore_num(void)
 {
-	return (2);
+	return (3);
 }

--- a/powerpc/ui_perf_map.c
+++ b/powerpc/ui_perf_map.c
@@ -26,28 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#include "../common/include/ui_perf_map.h"
 
-#include "../../common/include/types.h"
-
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8
-} cpu_type_t;
-
-#define CPU_TYPE_NUM    2
-
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
-
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+ui_perf_count_map_t ui_perf_count_map[UI_COUNT_NUM] = {
+	{ UI_COUNT_CORE_CLK, 0, { PERF_COUNT_INVALID, PERF_COUNT_INVALID } },
+	{ UI_COUNT_RMA,      2, { PERF_COUNT_RMA, PERF_COUNT_RMA_1 }       },
+	{ UI_COUNT_CLK,      1, { PERF_COUNT_CLK, PERF_COUNT_INVALID }     },
+	{ UI_COUNT_IR,       1, { PERF_COUNT_IR, PERF_COUNT_INVALID }      },
+	{ UI_COUNT_LMA,      1, { PERF_COUNT_LMA, PERF_COUNT_INVALID }     }
+};


### PR DESCRIPTION
Hi Jin,

Please pull few more patches.

First three are simple improvements for powerpc. Last one is quite big as it changes basic infrastructure of NumaTOP. NumaTOP assumes one perf event for one UI parameter. Which is not the case for powerpc. To count RMA on powerpc, two perf events needs to be programmed: PM_DATA_FROM_RMEM and PM_DATA_FROM_DMEM. Which is not possible with how NumaTOP is implemented. So I've changed that infrastructure and added new layer in between user frontend and perf backend which helps to transform UI parameter to perf events and vice versa.

Please review them and let me know if you find any issues.

Regards,
Ravi