### PR TITLE
IBM Power9 support and other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,19 +40,22 @@ TEST_PROG = $(TEST_PATH)/mgen
 TEST_OBJS = $(TEST_PATH)/mgen.o
 TEST_ARCH_OBJS = $(TEST_ARCH_PATH)/util.o
 
-%.o: ./common/%.c
+DEP := $(wildcard ./common/include/*.h) $(wildcard ./common/include/os/*.h) \
+	$(wildcard $(ARCH_PATH)/include/*.h) $(wildcard $(TEST_PATH)/include/*.h)
+
+%.o: ./common/%.c $(DEP)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-%.o: ./common/os/%.c
+%.o: ./common/os/%.c $(DEP)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-$(ARCH_PATH)/%.o: $(ARCH_PATH)/%.c
+$(ARCH_PATH)/%.o: $(ARCH_PATH)/%.c $(DEP)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-$(TEST_PATH)/%.o: $(TEST_PATH)/%.c
+$(TEST_PATH)/%.o: $(TEST_PATH)/%.c $(DEP)
 	$(CC) $(TEST_CFLAGS) -o $@ -c $<
 
-$(TEST_ARCH_PATH)/%o: $(TEST_ARCH_PATH)/%.c
+$(TEST_ARCH_PATH)/%o: $(TEST_ARCH_PATH)/%.c $(DEP)
 	$(CC) $(TEST_CFLAGS) -o $@ -c $<
 
 all: $(PROG) test

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ ARCH := $(shell uname -m)
 
 ifneq (,$(filter $(ARCH),ppc64le ppc64))
 ARCH_PATH = ./powerpc
-ARCH_OBJS = $(ARCH_PATH)/power8.o $(ARCH_PATH)/plat.o $(ARCH_PATH)/util.o \
-	$(ARCH_PATH)/ui_perf_map.o
+ARCH_OBJS = $(ARCH_PATH)/power8.o $(ARCH_PATH)/power9.o $(ARCH_PATH)/plat.o \
+	$(ARCH_PATH)/util.o $(ARCH_PATH)/ui_perf_map.o
 
 TEST_ARCH_PATH = $(TEST_PATH)/powerpc
 else

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PROG = numatop
 CC = gcc
 LD = gcc
 CFLAGS = -g -Wall -O2
+TEST_CFLAGS = -g -Wall -O0
 LDFLAGS = -g
 LDLIBS = -lncurses -lpthread -lnuma
 
@@ -48,8 +49,11 @@ TEST_ARCH_OBJS = $(TEST_ARCH_PATH)/util.o
 $(ARCH_PATH)/%.o: $(ARCH_PATH)/%.c
 	$(CC) $(CFLAGS) -o $@ -c $<
 
+$(TEST_PATH)/%.o: $(TEST_PATH)/%.c
+	$(CC) $(TEST_CFLAGS) -o $@ -c $<
+
 $(TEST_ARCH_PATH)/%o: $(TEST_ARCH_PATH)/%.c
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CC) $(TEST_CFLAGS) -o $@ -c $<
 
 all: $(PROG) test
 

--- a/numatop.8
+++ b/numatop.8
@@ -500,4 +500,4 @@ in 3.9. The following steps show how to get and apply the patch set.
 \fBnumatop\fP supports the Intel Xeon processors: 5500-series, 6500/7500-series, 
 5600 series, E7-x8xx-series, and E5-16xx/24xx/26xx/46xx-series. 
 \fBNote\fP: CPU microcode version 0x618 or 0x70c or later is required on
-E5-16xx/24xx/26xx/46xx-series. It also supports IBM Power8 processor.
+E5-16xx/24xx/26xx/46xx-series. It also supports IBM Power8 and Power9 processors.

--- a/powerpc/FEATURES
+++ b/powerpc/FEATURES
@@ -43,4 +43,4 @@ Other:
 
 | Feature                                                   | Supported     |
 |-----------------------------------------------------------|---------------|
-| mgen testcase                                             | N             |
+| mgen testcase                                             | Y             |

--- a/powerpc/include/power9.h
+++ b/powerpc/include/power9.h
@@ -26,31 +26,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#ifndef _NUMATOP_POWERPC_POWER9_H
+#define _NUMATOP_POWERPC_POWER9_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <inttypes.h>
 #include "../../common/include/types.h"
 
-#define CORP "IBM"
+struct _plat_event_config;
 
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8,
-	CPU_POWER9
-} cpu_type_t;
+extern void power9_profiling_config(perf_count_id_t, struct _plat_event_config *);
+extern void power9_ll_config(plat_event_config_t *cfg);
+extern int power9_offcore_num(void);
 
-#define CPU_TYPE_NUM    3
+#ifdef __cplusplus
+}
+#endif
 
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
-
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+#endif /* _NUMATOP_POWERPC_POWER9_H */

--- a/powerpc/plat.c
+++ b/powerpc/plat.c
@@ -34,27 +34,32 @@
 #include "../common/include/os/os_util.h"
 #include "include/types.h"
 #include "include/power8.h"
+#include "include/power9.h"
 
 pfn_plat_profiling_config_t
 s_plat_profiling_config[CPU_TYPE_NUM] = {
 	NULL,
-	power8_profiling_config
+	power8_profiling_config,
+	power9_profiling_config
 };
 
 pfn_plat_ll_config_t
 s_plat_ll_config[CPU_TYPE_NUM] = {
 	NULL,
-	power8_ll_config
+	power8_ll_config,
+	power9_ll_config
 };
 
 pfn_plat_offcore_num_t
 s_plat_offcore_num[CPU_TYPE_NUM] = {
 	NULL,
-	power8_offcore_num
+	power8_offcore_num,
+	power9_offcore_num
 };
 
 #define SPRN_PVR	0x11F
 #define PVR_VER(pvr)	(((pvr) >> 16) & 0xFFFF)
+#define PVR_REV(pvr)	(((pvr) >>  0) & 0xFFFF)
 
 int
 plat_detect(void)
@@ -71,6 +76,15 @@ plat_detect(void)
 	case 0x4d:
 		s_cpu_type = CPU_POWER8;
 		ret = 0;
+		break;
+	case 0x4e:
+		/* No support for Power9 DD1. */
+		if (PVR_REV(pvr) == 0x100)
+			break;
+
+		s_cpu_type = CPU_POWER9;
+		ret = 0;
+		break;
 	}
 
 	return ret;

--- a/powerpc/power9.c
+++ b/powerpc/power9.c
@@ -26,31 +26,44 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#include <inttypes.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <strings.h>
+#include "../common/include/os/linux/perf_event.h"
+#include "../common/include/os/plat.h"
+#include "include/power9.h"
 
-#include "../../common/include/types.h"
+static plat_event_config_t s_power9_profiling[PERF_COUNT_NUM] = {
+	{ PERF_TYPE_RAW, 0x600f4, 0, 0, "PM_RUN_CYC" },
+	{ PERF_TYPE_RAW, 0x4c04c, 0, 0, "PM_DATA_FROM_DMEM" },
+	{ PERF_TYPE_RAW, 0x1001e, 0, 0, "PM_CYC" },
+	{ PERF_TYPE_RAW, 0x500fa, 0, 0, "PM_RUN_INST_CMPL" },
+	{ PERF_TYPE_RAW, 0x2c048, 0, 0, "PM_DATA_FROM_LMEM" },
+	{ PERF_TYPE_RAW, 0x3c04a, 0, 0, "PM_DATA_FROM_RMEM" },
+};
 
-#define CORP "IBM"
+static plat_event_config_t s_power9_ll = {
+	PERF_TYPE_RAW, 0x0000, 0, 0, "PM_SUSPENDED"
+};
 
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8,
-	CPU_POWER9
-} cpu_type_t;
+void
+power9_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
+{
+	plat_config_get(perf_count_id, cfg, s_power9_profiling);
+}
 
-#define CPU_TYPE_NUM    3
+void
+power9_ll_config(plat_event_config_t *cfg)
+{
+	memcpy(cfg, &s_power9_ll, sizeof (plat_event_config_t));
+}
 
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
-
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+int
+power9_offcore_num(void)
+{
+	return (3);
+}


### PR DESCRIPTION
Hi Jin,

Please pull 3 more patches. One adds support for recently released processor Power9 by IBM. Other two patches fixes regression of commit 2956b875fc1e ("mgen: Reuse functions instead of redefining them").

Regards,
Ravi